### PR TITLE
Update template processor to compile with grunt-contrib-jasmine v1.0.3

### DIFF
--- a/src/template-jasmine-requirejs.js
+++ b/src/template-jasmine-requirejs.js
@@ -173,5 +173,5 @@ exports.process = function(grunt, task, context) {
                                context.temp);
 
   var source = grunt.file.read(template);
-  return grunt.util._.template(source, context);
+  return grunt.util._.template(source)(context);
 };


### PR DESCRIPTION
Sample template processor from https://github.com/gruntjs/grunt-contrib-jasmine/wiki/Jasmine-Templates#example-template-processor:

exports.process = function(grunt, task, context) {
  var source = grunt.file.read(template);
  return grunt.util._.template(source)(context);
};